### PR TITLE
Creata classe di eccezione

### DIFF
--- a/src/main/java/it/pagopa/pn/commons/exceptions/PnEncodingException.java
+++ b/src/main/java/it/pagopa/pn/commons/exceptions/PnEncodingException.java
@@ -1,0 +1,14 @@
+package it.pagopa.pn.commons.exceptions;
+
+public class PnEncodingException extends IllegalArgumentException{
+
+    public PnEncodingException() {}
+
+    public PnEncodingException(String message) {
+        super(message);
+    }
+
+    public PnEncodingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Creata classe di eccezione per la validazione del base64 e lo sha256 in NotificationReceiverValidator