### PR TITLE
PN-2896 aggiunto handler che logga error per SQS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,9 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-core</artifactId>
+			<groupId>de.idealo.spring</groupId>
+			<artifactId>spring-cloud-stream-binder-sqs</artifactId>
+			<version>1.9.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,10 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-core</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/it/pagopa/pn/commons/utils/CustomAWSRequestHandler.java
+++ b/src/main/java/it/pagopa/pn/commons/utils/CustomAWSRequestHandler.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.commons.utils;
+
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.handlers.RequestHandler2;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Questa Handler cattura tutte le richieste, risposte ed errori di oggetti di AWS come
+ * com.amazonaws.services.sqs.AmazonSQSAsync.
+ * È possibile catturare gli eventi sovrascrivendo i metodi di {@link RequestHandler2}.
+ * <p>
+ * È possibile associare l'Handler durante la creazione dell'oggetto AWS, ad esempio:
+ * <p>
+ * AmazonSQSAsyncClientBuilder.standard()
+ *             .withRequestHandlers(new CustomAWSRequestHandler())
+ *             .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(awsConfigs.getEndpointUrl(), awsConfigs.getRegionCode()))
+ *             .build();
+ *
+ */
+@Slf4j
+public class CustomAWSRequestHandler extends RequestHandler2 {
+
+    @Override
+    public void afterError(Request<?> request, Response<?> response, Exception e) {
+        log.error("Exception for: " + request.getOriginalRequestObject().toString(), e);
+    }
+}

--- a/src/main/java/it/pagopa/pn/commons/utils/CustomAWSRequestHandler.java
+++ b/src/main/java/it/pagopa/pn/commons/utils/CustomAWSRequestHandler.java
@@ -23,6 +23,6 @@ public class CustomAWSRequestHandler extends RequestHandler2 {
 
     @Override
     public void afterError(Request<?> request, Response<?> response, Exception e) {
-        log.error("Exception for: " + request.getOriginalRequestObject().toString(), e);
+        log.error("Exception for: " + request.getOriginalRequestObject(), e);
     }
 }

--- a/src/test/java/it/pagopa/pn/commons/utils/CustomAWSRequestHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/commons/utils/CustomAWSRequestHandlerTest.java
@@ -1,0 +1,15 @@
+package it.pagopa.pn.commons.utils;
+
+import com.amazonaws.DefaultRequest;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class CustomAWSRequestHandlerTest {
+
+
+    @Test
+    void test() {
+        CustomAWSRequestHandler handler = new CustomAWSRequestHandler();
+        assertDoesNotThrow(() -> handler.afterError(new DefaultRequest<>("SQS"), null, new RuntimeException()));
+    }
+}


### PR DESCRIPTION
Esempio di log dell'Handler:

2022-12-29 11:23:14,747 [] ERROR - 3988 - [main] - i.p.p.c.u.CustomAWSRequestHandler - Exception for: {QueueName: local-delivery-push-inputs.fifo,} 
com.amazonaws.services.sqs.model.QueueDoesNotExistException: The specified queue does not exist for this wsdl version. (Service: AmazonSQS; Status Code: 400; Error Code: AWS.SimpleQueueService.NonExistentQueue; Request ID: AFJUTR9W3WB7VT5OK5NDMTAGXY2THMWQPIXMWODE3N5DOTHO95D2; Proxy: null)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1879)
	...