### PR TITLE
PN-3532 configurazione per log MDC in thread async di aws-sdk

### DIFF
--- a/src/main/java/it/pagopa/pn/commons/configs/aws/AwsServicesClientsConfig.java
+++ b/src/main/java/it/pagopa/pn/commons/configs/aws/AwsServicesClientsConfig.java
@@ -1,6 +1,8 @@
 package it.pagopa.pn.commons.configs.aws;
 
 import it.pagopa.pn.commons.configs.RuntimeMode;
+import it.pagopa.pn.commons.utils.DynamoDbAsyncClientDecorator;
+import it.pagopa.pn.commons.utils.DynamoDbEnhancedAsyncClientDecorator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -31,16 +33,26 @@ public class AwsServicesClientsConfig {
         log.info("AWS RuntimeMode is={}", runtimeMode);
     }
 
-    @Bean
+//    @Bean
     public DynamoDbAsyncClient dynamoDbAsyncClient() {
         return this.configureBuilder( DynamoDbAsyncClient.builder() );
     }
 
-    @Bean
+//    @Bean
     public DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient( DynamoDbAsyncClient baseAsyncClient) {
         return DynamoDbEnhancedAsyncClient.builder()
                 .dynamoDbClient( baseAsyncClient )
                 .build();
+    }
+
+    @Bean
+    public DynamoDbAsyncClient dynamoDbAsyncClientWithMDC() {
+        return new DynamoDbAsyncClientDecorator(this.dynamoDbAsyncClient());
+    }
+
+    @Bean
+    public DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClientWithMDC(DynamoDbAsyncClient delegate) {
+        return new DynamoDbEnhancedAsyncClientDecorator(this.dynamoDbEnhancedAsyncClient(delegate));
     }
 
     @Bean

--- a/src/main/java/it/pagopa/pn/commons/utils/DynamoDbAsyncClientDecorator.java
+++ b/src/main/java/it/pagopa/pn/commons/utils/DynamoDbAsyncClientDecorator.java
@@ -1,0 +1,109 @@
+package it.pagopa.pn.commons.utils;
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.awssdk.services.dynamodb.paginators.QueryPublisher;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class DynamoDbAsyncClientDecorator implements DynamoDbAsyncClient {
+
+    private final DynamoDbAsyncClient dynamoDbAsyncClient;
+
+    public DynamoDbAsyncClientDecorator(DynamoDbAsyncClient dynamoDbAsyncClient) {
+        this.dynamoDbAsyncClient = dynamoDbAsyncClient;
+    }
+
+    @Override
+    public String serviceName() {
+        return this.dynamoDbAsyncClient.serviceName();
+    }
+
+    @Override
+    public void close() {
+        this.dynamoDbAsyncClient.close();
+    }
+
+    @Override
+    public CompletableFuture<QueryResponse> query(Consumer<QueryRequest.Builder> queryRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.query(queryRequest)
+                .thenApply(queryResponse -> MDCUtils.enrichWithMDC(queryResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<QueryResponse> query(QueryRequest queryRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.query(queryRequest)
+                .thenApply(queryResponse -> MDCUtils.enrichWithMDC(queryResponse, copyOfContextMap));
+    }
+
+    // nei metodi queryPaginator non aggiungiamo l'MDC perché il metodo richiama il metodo query che già ha l'MDC
+    @Override
+    public QueryPublisher queryPaginator(Consumer<QueryRequest.Builder> queryRequest) {
+        return this.dynamoDbAsyncClient.queryPaginator(queryRequest);
+    }
+
+    @Override
+    public QueryPublisher queryPaginator(QueryRequest queryRequest) {
+        return this.dynamoDbAsyncClient.queryPaginator(queryRequest);
+    }
+
+    @Override
+    public CompletableFuture<PutItemResponse> putItem(Consumer<PutItemRequest.Builder> putItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.putItem(putItemRequest)
+                .thenApply(putItemResponse -> MDCUtils.enrichWithMDC(putItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<PutItemResponse> putItem(PutItemRequest putItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.putItem(putItemRequest)
+                .thenApply(putItemResponse -> MDCUtils.enrichWithMDC(putItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<TransactWriteItemsResponse> transactWriteItems(Consumer<TransactWriteItemsRequest.Builder> transactWriteItemsRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.transactWriteItems(transactWriteItemsRequest)
+                .thenApply(transactWriteItemsResponse -> MDCUtils.enrichWithMDC(transactWriteItemsResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<TransactWriteItemsResponse> transactWriteItems(TransactWriteItemsRequest transactWriteItemsRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.transactWriteItems(transactWriteItemsRequest)
+                .thenApply(transactWriteItemsResponse -> MDCUtils.enrichWithMDC(transactWriteItemsResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<GetItemResponse> getItem(Consumer<GetItemRequest.Builder> getItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.getItem(getItemRequest)
+                .thenApply(getItemResponse -> MDCUtils.enrichWithMDC(getItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<GetItemResponse> getItem(GetItemRequest getItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.getItem(getItemRequest)
+                .thenApply(getItemResponse -> MDCUtils.enrichWithMDC(getItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<DeleteItemResponse> deleteItem(Consumer<DeleteItemRequest.Builder> deleteItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.deleteItem(deleteItemRequest)
+                .thenApply(deleteItemResponse -> MDCUtils.enrichWithMDC(deleteItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<DeleteItemResponse> deleteItem(DeleteItemRequest deleteItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.deleteItem(deleteItemRequest)
+                .thenApply(deleteItemResponse -> MDCUtils.enrichWithMDC(deleteItemResponse, copyOfContextMap));
+    }
+}

--- a/src/main/java/it/pagopa/pn/commons/utils/DynamoDbAsyncIndexDecorator.java
+++ b/src/main/java/it/pagopa/pn/commons/utils/DynamoDbAsyncIndexDecorator.java
@@ -1,0 +1,71 @@
+package it.pagopa.pn.commons.utils;
+
+
+import lombok.EqualsAndHashCode;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+@EqualsAndHashCode
+public class DynamoDbAsyncIndexDecorator<T> implements DynamoDbAsyncIndex<T> {
+
+    private final DynamoDbAsyncIndex<T> tDynamoDbAsyncIndex;
+
+    public DynamoDbAsyncIndexDecorator(DynamoDbAsyncIndex<T> tDynamoDbAsyncIndex) {
+        this.tDynamoDbAsyncIndex = tDynamoDbAsyncIndex;
+    }
+
+    @Override
+    public DynamoDbEnhancedClientExtension mapperExtension() {
+        return this.tDynamoDbAsyncIndex.mapperExtension();
+    }
+
+    @Override
+    public TableSchema<T> tableSchema() {
+        return this.tDynamoDbAsyncIndex.tableSchema();
+    }
+
+    @Override
+    public String tableName() {
+        return this.tDynamoDbAsyncIndex.tableName();
+    }
+
+    @Override
+    public String indexName() {
+        return this.tDynamoDbAsyncIndex.indexName();
+    }
+
+    @Override
+    public Key keyFrom(T item) {
+        return this.tDynamoDbAsyncIndex.keyFrom(item);
+    }
+
+    @Override
+    public SdkPublisher<Page<T>> query(QueryConditional queryConditional) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.tDynamoDbAsyncIndex.query(queryConditional)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+    }
+
+    @Override
+    public SdkPublisher<Page<T>> query(QueryEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.tDynamoDbAsyncIndex.query(request)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+    }
+
+    @Override
+    public SdkPublisher<Page<T>> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.tDynamoDbAsyncIndex.query(requestConsumer)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+    }
+}

--- a/src/main/java/it/pagopa/pn/commons/utils/DynamoDbAsyncTableDecorator.java
+++ b/src/main/java/it/pagopa/pn/commons/utils/DynamoDbAsyncTableDecorator.java
@@ -1,0 +1,147 @@
+package it.pagopa.pn.commons.utils;
+
+import lombok.EqualsAndHashCode;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.enhanced.dynamodb.*;
+import software.amazon.awssdk.enhanced.dynamodb.model.*;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+@EqualsAndHashCode
+public class DynamoDbAsyncTableDecorator<T> implements DynamoDbAsyncTable<T> {
+
+    private final DynamoDbAsyncTable<T> dynamoDbAsyncTable;
+
+    public DynamoDbAsyncTableDecorator(DynamoDbAsyncTable<T> dynamoDbAsyncTable) {
+        this.dynamoDbAsyncTable = dynamoDbAsyncTable;
+    }
+
+    @Override
+    public DynamoDbAsyncIndex<T> index(String s) {
+        DynamoDbAsyncIndex<T> index = this.dynamoDbAsyncTable.index(s);
+        return new DynamoDbAsyncIndexDecorator<>(index);
+    }
+
+    @Override
+    public DynamoDbEnhancedClientExtension mapperExtension() {
+        return this.dynamoDbAsyncTable.mapperExtension();
+    }
+
+    @Override
+    public TableSchema<T> tableSchema() {
+        return this.dynamoDbAsyncTable.tableSchema();
+    }
+
+    @Override
+    public String tableName() {
+        return this.dynamoDbAsyncTable.tableName();
+    }
+
+    @Override
+    public Key keyFrom(T t) {
+        return this.dynamoDbAsyncTable.keyFrom(t);
+    }
+
+    @Override
+    public PagePublisher<T> query(QueryEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        SdkPublisher<Page<T>> map = this.dynamoDbAsyncTable.query(request)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+        return PagePublisher.create(map);
+    }
+
+    @Override
+    public PagePublisher<T> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        SdkPublisher<Page<T>> publisherWithMDC = this.dynamoDbAsyncTable.query(requestConsumer)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+        return PagePublisher.create(publisherWithMDC);
+    }
+
+    @Override
+    public PagePublisher<T> query(QueryConditional queryConditional) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        SdkPublisher<Page<T>> publisherWithMDC = this.dynamoDbAsyncTable.query(queryConditional)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+        return PagePublisher.create(publisherWithMDC);
+    }
+
+    @Override
+    public CompletableFuture<Void> putItem(PutItemEnhancedRequest<T> request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.putItem(request)
+                .thenApply(unused -> MDCUtils.enrichWithMDC(unused, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<Void> putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.putItem(requestConsumer)
+                .thenApply(unused -> MDCUtils.enrichWithMDC(unused, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<Void> putItem(T item) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.putItem(item)
+                .thenApply(unused -> MDCUtils.enrichWithMDC(unused, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(Key key) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.getItem(key)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(T keyItem) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.getItem(keyItem)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(Consumer<GetItemEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.getItem(requestConsumer)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(GetItemEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.getItem(request)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> deleteItem(Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.deleteItem(requestConsumer)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> deleteItem(DeleteItemEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.deleteItem(request)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> deleteItem(Key key) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.deleteItem(key)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> deleteItem(T keyItem) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.deleteItem(keyItem)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+}

--- a/src/main/java/it/pagopa/pn/commons/utils/DynamoDbEnhancedAsyncClientDecorator.java
+++ b/src/main/java/it/pagopa/pn/commons/utils/DynamoDbEnhancedAsyncClientDecorator.java
@@ -1,0 +1,40 @@
+package it.pagopa.pn.commons.utils;
+
+import lombok.EqualsAndHashCode;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+@EqualsAndHashCode
+public class DynamoDbEnhancedAsyncClientDecorator implements DynamoDbEnhancedAsyncClient {
+
+    private final DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient;
+
+    public DynamoDbEnhancedAsyncClientDecorator(DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient) {
+        this.dynamoDbEnhancedAsyncClient = dynamoDbEnhancedAsyncClient;
+    }
+
+    @Override
+    public <T> DynamoDbAsyncTable<T> table(String s, TableSchema<T> tableSchema) {
+        return new DynamoDbAsyncTableDecorator<>(this.dynamoDbEnhancedAsyncClient.table(s, tableSchema));
+    }
+
+    @Override
+    public CompletableFuture<Void> transactWriteItems(Consumer<TransactWriteItemsEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbEnhancedAsyncClient.transactWriteItems(requestConsumer)
+                .thenApply(queryResponse -> MDCUtils.enrichWithMDC(queryResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<Void> transactWriteItems(TransactWriteItemsEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbEnhancedAsyncClient.transactWriteItems(request)
+                .thenApply(queryResponse -> MDCUtils.enrichWithMDC(queryResponse, copyOfContextMap));
+    }
+}

--- a/src/main/java/it/pagopa/pn/commons/utils/MDCUtils.java
+++ b/src/main/java/it/pagopa/pn/commons/utils/MDCUtils.java
@@ -1,0 +1,22 @@
+package it.pagopa.pn.commons.utils;
+
+import org.slf4j.MDC;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Map;
+
+public class MDCUtils {
+
+    private MDCUtils() {}
+
+    public static Map<String, String> retrieveMDCContextMap() {
+        return MDC.getCopyOfContextMap();
+    }
+
+    public static <V> V enrichWithMDC(V t, Map<String, String> copyOfContextMap) {
+        if(! CollectionUtils.isEmpty(copyOfContextMap)) {
+            MDC.setContextMap(copyOfContextMap);
+        }
+        return t;
+    }
+}

--- a/src/test/java/it/pagopa/pn/commons/utils/DynamoDbAsyncClientDecoratorTest.java
+++ b/src/test/java/it/pagopa/pn/commons/utils/DynamoDbAsyncClientDecoratorTest.java
@@ -1,0 +1,144 @@
+package it.pagopa.pn.commons.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.awssdk.services.dynamodb.paginators.QueryPublisher;
+import software.amazon.awssdk.utils.builder.SdkBuilder;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class DynamoDbAsyncClientDecoratorTest {
+
+    private DynamoDbAsyncClientDecorator dynamoDbAsyncClientDecorator;
+
+    private DynamoDbAsyncClient delegate;
+
+    @BeforeEach
+    public void init() {
+        delegate = Mockito.mock(DynamoDbAsyncClient.class);
+        dynamoDbAsyncClientDecorator = new DynamoDbAsyncClientDecorator(delegate);
+    }
+
+    @Test
+    void serviceNameTest() {
+        Mockito.when(delegate.serviceName()).thenReturn("SERVICE");
+        assertThat(dynamoDbAsyncClientDecorator.serviceName()).isEqualTo("SERVICE");
+    }
+
+    @Test
+    void closeTest() {
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncClientDecorator.close());
+    }
+
+
+    @Test
+    void queryTest() throws ExecutionException, InterruptedException {
+        QueryRequest mock = QueryRequest.builder().build();
+        QueryResponse expectedValue = QueryResponse.builder().build();
+        Mockito.when(delegate.query(mock)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.query(mock).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void queryConsumerTest() throws ExecutionException, InterruptedException {
+        Consumer<QueryRequest.Builder> consumer = SdkBuilder::build;
+        QueryResponse expectedValue = QueryResponse.builder().build();
+        Mockito.when(delegate.query(consumer)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.query(consumer).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void queryPaginatorTest() {
+        QueryRequest mock = QueryRequest.builder().build();
+        QueryPublisher publisher = Mockito.mock(QueryPublisher.class);
+        Mockito.when(delegate.queryPaginator(mock)).thenReturn(publisher);
+        assertThat(dynamoDbAsyncClientDecorator.queryPaginator(mock)).isEqualTo(publisher);
+    }
+
+    @Test
+    void queryPaginatorConsumerTest() {
+        Consumer<QueryRequest.Builder> consumer = SdkBuilder::build;
+        QueryPublisher publisher = Mockito.mock(QueryPublisher.class);
+        Mockito.when(delegate.queryPaginator(consumer)).thenReturn(publisher);
+        assertThat(dynamoDbAsyncClientDecorator.queryPaginator(consumer)).isEqualTo(publisher);
+    }
+
+    @Test
+    void putItemTest() throws ExecutionException, InterruptedException {
+        PutItemRequest putItemRequest = PutItemRequest.builder().build();
+        PutItemResponse expectedValue = PutItemResponse.builder().consumedCapacity(ConsumedCapacity.builder().tableName("TABLE").build()).build();
+        Mockito.when(delegate.putItem(putItemRequest)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.putItem(putItemRequest).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void putItemConsumerTest() throws ExecutionException, InterruptedException {
+        Consumer<PutItemRequest.Builder> consumer = SdkBuilder::build;
+        PutItemResponse expectedValue = PutItemResponse.builder().consumedCapacity(ConsumedCapacity.builder().tableName("TABLE").build()).build();
+        Mockito.when(delegate.putItem(consumer)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.putItem(consumer).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void transactWriteItemsTest() throws ExecutionException, InterruptedException {
+        TransactWriteItemsRequest request = TransactWriteItemsRequest.builder().build();
+        TransactWriteItemsResponse expectedValue = TransactWriteItemsResponse.builder().consumedCapacity(ConsumedCapacity
+                .builder().tableName("TABLE").build())
+                .build();
+
+        Mockito.when(delegate.transactWriteItems(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.transactWriteItems(request).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void transactWriteItemsConsumerTest() throws ExecutionException, InterruptedException {
+        Consumer<TransactWriteItemsRequest.Builder> consumer = SdkBuilder::build;
+        TransactWriteItemsResponse expectedValue = TransactWriteItemsResponse.builder().consumedCapacity(ConsumedCapacity
+                        .builder().tableName("TABLE").build())
+                .build();
+
+        Mockito.when(delegate.transactWriteItems(consumer)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.transactWriteItems(consumer).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void getItemTest() throws ExecutionException, InterruptedException {
+        GetItemRequest request = GetItemRequest.builder().build();
+        GetItemResponse expectedValue = GetItemResponse.builder().consumedCapacity(ConsumedCapacity.builder().tableName("TABLE").build()).build();
+        Mockito.when(delegate.getItem(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.getItem(request).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void getItemConsumerTest() throws ExecutionException, InterruptedException {
+        Consumer<GetItemRequest.Builder> consumer = SdkBuilder::build;
+        GetItemResponse expectedValue = GetItemResponse.builder().consumedCapacity(ConsumedCapacity.builder().tableName("TABLE").build()).build();
+        Mockito.when(delegate.getItem(consumer)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.getItem(consumer).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void deleteItemTest() throws ExecutionException, InterruptedException {
+        DeleteItemRequest request = DeleteItemRequest.builder().build();
+        DeleteItemResponse expectedValue = DeleteItemResponse.builder().consumedCapacity(ConsumedCapacity.builder().tableName("TABLE").build()).build();
+        Mockito.when(delegate.deleteItem(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.deleteItem(request).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void deleteItemConsumerTest() throws ExecutionException, InterruptedException {
+        Consumer<DeleteItemRequest.Builder> consumer = SdkBuilder::build;
+        DeleteItemResponse expectedValue = DeleteItemResponse.builder().consumedCapacity(ConsumedCapacity.builder().tableName("TABLE").build()).build();
+        Mockito.when(delegate.deleteItem(consumer)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncClientDecorator.deleteItem(consumer).get()).isEqualTo(expectedValue);
+    }
+
+}

--- a/src/test/java/it/pagopa/pn/commons/utils/DynamoDbAsyncIndexDecoratorTest.java
+++ b/src/test/java/it/pagopa/pn/commons/utils/DynamoDbAsyncIndexDecoratorTest.java
@@ -1,0 +1,91 @@
+package it.pagopa.pn.commons.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class DynamoDbAsyncIndexDecoratorTest {
+
+    private DynamoDbAsyncIndexDecorator<String> dynamoDbAsyncIndexDecorator;
+
+    private DynamoDbAsyncIndex<String> delegate;
+
+    @BeforeEach
+    public void init() {
+        delegate = Mockito.mock(DynamoDbAsyncIndex.class);
+        dynamoDbAsyncIndexDecorator = new DynamoDbAsyncIndexDecorator<>(delegate);
+    }
+
+    @Test
+    void mapperExtensionTest() {
+        DynamoDbEnhancedClientExtension expectedValue = delegate.mapperExtension();
+        Mockito.when(delegate.mapperExtension()).thenReturn(expectedValue);
+        assertThat(dynamoDbAsyncIndexDecorator.mapperExtension()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void tableSchemaTest() {
+        TableSchema<String> expectedValue = delegate.tableSchema();
+        Mockito.when(delegate.tableSchema()).thenReturn(expectedValue);
+        assertThat(dynamoDbAsyncIndexDecorator.tableSchema()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void indexNameTest() {
+        Mockito.when(delegate.indexName()).thenReturn("INDICE");
+        assertThat(dynamoDbAsyncIndexDecorator.indexName()).isEqualTo("INDICE");
+    }
+
+    @Test
+    void tableNameTest() {
+        Mockito.when(delegate.tableName()).thenReturn("MANDATE");
+        assertThat(dynamoDbAsyncIndexDecorator.tableName()).isEqualTo("MANDATE");
+    }
+
+    @Test
+    void keyFromTest() {
+        Key key = delegate.keyFrom("A");
+        Mockito.when(delegate.keyFrom("A")).thenReturn(key);
+        assertThat(dynamoDbAsyncIndexDecorator.keyFrom("A")).isEqualTo(key);
+    }
+
+    @Test
+    void queryTest() {
+        QueryConditional mock = QueryConditional.keyEqualTo(Key.builder().partitionValue(1).build());
+        SdkPublisher<Page<String>> sdkPublisher = SdkPublisher.adapt(Mono.just(Page.create(List.of(""))));
+        Mockito.when(delegate.query(mock)).thenReturn(sdkPublisher);
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncIndexDecorator.query(mock));
+    }
+
+    @Test
+    void queryConsumerTest() {
+        Consumer<QueryEnhancedRequest.Builder> mock = Mockito.mock(Consumer.class);
+        SdkPublisher<Page<String>> sdkPublisher = Mockito.mock(SdkPublisher.class);
+        Mockito.when(delegate.query(mock)).thenReturn(sdkPublisher);
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncIndexDecorator.query(mock));
+    }
+
+    @Test
+    void queryEnhancedRequestTest() {
+        QueryEnhancedRequest mock = QueryEnhancedRequest.builder().build();
+        SdkPublisher<Page<String>> sdkPublisher = Mockito.mock(SdkPublisher.class);
+        Mockito.when(delegate.query(mock)).thenReturn(sdkPublisher);
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncIndexDecorator.query(mock));
+    }
+
+}

--- a/src/test/java/it/pagopa/pn/commons/utils/DynamoDbAsyncTableDecoratorTest.java
+++ b/src/test/java/it/pagopa/pn/commons/utils/DynamoDbAsyncTableDecoratorTest.java
@@ -1,0 +1,171 @@
+package it.pagopa.pn.commons.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.enhanced.dynamodb.*;
+import software.amazon.awssdk.enhanced.dynamodb.model.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class DynamoDbAsyncTableDecoratorTest {
+
+    private DynamoDbAsyncTableDecorator<String> dynamoDbAsyncTableDecorator;
+
+    private DynamoDbAsyncTable<String> delegate;
+
+    @BeforeEach
+    public void init() {
+        delegate = Mockito.mock(DynamoDbAsyncTable.class);
+        dynamoDbAsyncTableDecorator = new DynamoDbAsyncTableDecorator<>(delegate);
+    }
+
+    @Test
+    void mapperExtensionTest() {
+        DynamoDbEnhancedClientExtension expectedValue = delegate.mapperExtension();
+        Mockito.when(delegate.mapperExtension()).thenReturn(expectedValue);
+        assertThat(dynamoDbAsyncTableDecorator.mapperExtension()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void tableSchemaTest() {
+        TableSchema<String> expectedValue = delegate.tableSchema();
+        Mockito.when(delegate.tableSchema()).thenReturn(expectedValue);
+        assertThat(dynamoDbAsyncTableDecorator.tableSchema()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void indexTest() {
+        DynamoDbAsyncIndex<String> index = Mockito.mock(DynamoDbAsyncIndex.class);
+        Mockito.when(delegate.index("INDEX")).thenReturn(index);
+        assertThat(dynamoDbAsyncTableDecorator.index("INDEX")).isEqualTo(new DynamoDbAsyncIndexDecorator<>(index));
+    }
+
+    @Test
+    void tableNameTest() {
+        Mockito.when(delegate.tableName()).thenReturn("MANDATE");
+        assertThat(dynamoDbAsyncTableDecorator.tableName()).isEqualTo("MANDATE");
+    }
+
+    @Test
+    void keyFromTest() {
+        Key key = delegate.keyFrom("A");
+        Mockito.when(delegate.keyFrom("A")).thenReturn(key);
+        assertThat(dynamoDbAsyncTableDecorator.keyFrom("A")).isEqualTo(key);
+    }
+
+    @Test
+    void queryTest() {
+        QueryEnhancedRequest request = QueryEnhancedRequest.builder().build();
+        PagePublisher<String> publisher = Subscriber::onComplete;
+        Mockito.when(delegate.query(request)).thenReturn(publisher);
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncTableDecorator.query(request));
+    }
+
+    @Test
+    void queryConsumerTest() {
+        Consumer<QueryEnhancedRequest.Builder> consumer = QueryEnhancedRequest.Builder::build;
+        PagePublisher<String> publisher = Subscriber::onComplete;
+        Mockito.when(delegate.query(consumer)).thenReturn(publisher);
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncTableDecorator.query(consumer));
+    }
+
+    @Test
+    void queryConditionalConsumerTest() {
+        QueryConditional queryConditional = QueryConditional.keyEqualTo(Key.builder().partitionValue(1).build());
+        PagePublisher<String> publisher = Subscriber::onComplete;
+        Mockito.when(delegate.query(queryConditional)).thenReturn(publisher);
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncTableDecorator.query(queryConditional));
+    }
+
+    @Test
+    void putItemTest() {
+        PutItemEnhancedRequest<String> request = PutItemEnhancedRequest.builder(String.class).build();
+        Mockito.when(delegate.putItem(request)).thenReturn(CompletableFuture.completedFuture(null));
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncTableDecorator.putItem(request));
+    }
+
+    @Test
+    void putItemConsumerTest() {
+        Consumer<PutItemEnhancedRequest.Builder<String>> consumer = PutItemEnhancedRequest.Builder::build;
+        Mockito.when(delegate.putItem(consumer)).thenReturn(CompletableFuture.completedFuture(null));
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncTableDecorator.putItem(consumer));
+    }
+
+    @Test
+    void putItemGenericTest() {
+        String request = "REQUEST";
+        Mockito.when(delegate.putItem(request)).thenReturn(CompletableFuture.completedFuture(null));
+        Assertions.assertDoesNotThrow(() -> dynamoDbAsyncTableDecorator.putItem(request));
+    }
+
+    @Test
+    void getItemTest() throws ExecutionException, InterruptedException {
+        String request = "REQUEST";
+        String expectedValue = "RESPONSE";
+        Mockito.when(delegate.getItem(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncTableDecorator.getItem(request).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void getItemKeyTest() throws ExecutionException, InterruptedException {
+        Key request = Key.builder().partitionValue(1).build();
+        String expectedValue = "RESPONSE";
+        Mockito.when(delegate.getItem(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncTableDecorator.getItem(request).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void getItemConsumerTest() throws ExecutionException, InterruptedException {
+        Consumer<GetItemEnhancedRequest.Builder> consumer = GetItemEnhancedRequest.Builder::build;
+        String expectedValue = "RESPONSE";
+        Mockito.when(delegate.getItem(consumer)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncTableDecorator.getItem(consumer).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void getItemEnhancedRequestTest() throws ExecutionException, InterruptedException {
+        GetItemEnhancedRequest request = GetItemEnhancedRequest.builder().build();
+        String expectedValue = "RESPONSE";
+        Mockito.when(delegate.getItem(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncTableDecorator.getItem(request).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void deleteItemTest() throws ExecutionException, InterruptedException {
+        String request = "REQUEST";
+        String expectedValue = "RESPONSE";
+        Mockito.when(delegate.deleteItem(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncTableDecorator.deleteItem(request).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void deleteItemKeyTest() throws ExecutionException, InterruptedException {
+        Key request = Key.builder().partitionValue(1).build();
+        String expectedValue = "RESPONSE";
+        Mockito.when(delegate.deleteItem(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncTableDecorator.deleteItem(request).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void deleteItemConsumerTest() throws ExecutionException, InterruptedException {
+        Consumer<DeleteItemEnhancedRequest.Builder> consumer = DeleteItemEnhancedRequest.Builder::build;
+        String expectedValue = "RESPONSE";
+        Mockito.when(delegate.deleteItem(consumer)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncTableDecorator.deleteItem(consumer).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void deleteItemEnhancedRequestTest() throws ExecutionException, InterruptedException {
+        DeleteItemEnhancedRequest request = DeleteItemEnhancedRequest.builder().build();
+        String expectedValue = "RESPONSE";
+        Mockito.when(delegate.deleteItem(request)).thenReturn(CompletableFuture.completedFuture(expectedValue));
+        assertThat(dynamoDbAsyncTableDecorator.deleteItem(request).get()).isEqualTo(expectedValue);
+    }
+}

--- a/src/test/java/it/pagopa/pn/commons/utils/DynamoDbEnhancedAsyncClientDecoratorTest.java
+++ b/src/test/java/it/pagopa/pn/commons/utils/DynamoDbEnhancedAsyncClientDecoratorTest.java
@@ -1,0 +1,50 @@
+package it.pagopa.pn.commons.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class DynamoDbEnhancedAsyncClientDecoratorTest {
+
+    private DynamoDbEnhancedAsyncClientDecorator dynamoDbEnhancedAsyncClientDecorator;
+
+    private DynamoDbEnhancedAsyncClient delegate;
+
+    @BeforeEach
+    public void init() {
+        delegate = Mockito.mock(DynamoDbEnhancedAsyncClient.class);
+        dynamoDbEnhancedAsyncClientDecorator = new DynamoDbEnhancedAsyncClientDecorator(delegate);
+    }
+
+    @Test
+    void tableTest() {
+        TableSchema<String> tableSchema = Mockito.mock(TableSchema.class);
+        DynamoDbAsyncTable<String> mandateTable = delegate.table("MANDATE", tableSchema);
+        Mockito.when(delegate.table("MANDATE", tableSchema)).thenReturn(mandateTable);
+        assertThat(dynamoDbEnhancedAsyncClientDecorator.table("MANDATE", tableSchema)).isEqualTo(new DynamoDbAsyncTableDecorator<>(mandateTable));
+    }
+
+    @Test
+    void transactWriteItemsTest() {
+        TransactWriteItemsEnhancedRequest request = TransactWriteItemsEnhancedRequest.builder().build();
+        Mockito.when(delegate.transactWriteItems(request)).thenReturn(CompletableFuture.completedFuture(null));
+        Assertions.assertDoesNotThrow(() -> dynamoDbEnhancedAsyncClientDecorator.transactWriteItems(request));
+    }
+
+    @Test
+    void transactWriteItemsConsumerTest() {
+        Consumer<TransactWriteItemsEnhancedRequest.Builder> consumer = TransactWriteItemsEnhancedRequest.Builder::build;
+        Mockito.when(delegate.transactWriteItems(consumer)).thenReturn(CompletableFuture.completedFuture(null));
+        Assertions.assertDoesNotThrow(() -> dynamoDbEnhancedAsyncClientDecorator.transactWriteItems(consumer));
+    }
+}

--- a/src/test/java/it/pagopa/pn/commons/utils/MDCUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/commons/utils/MDCUtilsTest.java
@@ -1,0 +1,45 @@
+package it.pagopa.pn.commons.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MDCUtilsTest {
+
+
+    @BeforeEach
+    public void init() {
+        MDC.put("key", "value");
+    }
+
+    @AfterEach
+    public void clean() {
+        MDC.clear();
+    }
+
+    @Test
+    void retrieveMDCContextMapTest() {
+        Map<String, String> map = MDCUtils.retrieveMDCContextMap();
+        assertThat(map)
+                .isNotEmpty()
+                .hasSize(1)
+                .containsKey("key");
+    }
+
+    @Test
+    void enrichWithMDCTest() {
+        Map<String, String> anotherMap = Map.of("anotherKey", "anotherValue");
+        String actualValue = MDCUtils.enrichWithMDC("aValueReturned", anotherMap);
+        assertThat(actualValue).isEqualTo("aValueReturned");
+        assertThat(MDC.getCopyOfContextMap())
+                .isNotEmpty()
+                .hasSize(1)
+                .containsKey("anotherKey");
+
+    }
+}


### PR DESCRIPTION
Centralizzata configurazione dei log MDC su sdk-async di AWS. Dopo il merge di questa PR, eliminare la stessa configurazione in pn-mandate.