### PR TITLE
Aggiunti metodi batchGetItem nel DynamoDB decorator

### DIFF
--- a/src/main/java/it/pagopa/pn/commons/utils/DynamoDbAsyncClientDecorator.java
+++ b/src/main/java/it/pagopa/pn/commons/utils/DynamoDbAsyncClientDecorator.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.commons.utils;
 
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.awssdk.services.dynamodb.paginators.BatchGetItemPublisher;
 import software.amazon.awssdk.services.dynamodb.paginators.QueryPublisher;
 
 import java.util.Map;
@@ -77,6 +78,12 @@ public class DynamoDbAsyncClientDecorator implements DynamoDbAsyncClient {
         Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
         return this.dynamoDbAsyncClient.transactWriteItems(transactWriteItemsRequest)
                 .thenApply(transactWriteItemsResponse -> MDCUtils.enrichWithMDC(transactWriteItemsResponse, copyOfContextMap));
+    }
+
+    @Override
+    public BatchGetItemPublisher batchGetItemPaginator(BatchGetItemRequest batchGetItemRequest) {
+        // richiamato internamente da DynamoDbEnhancedAsyncClient.batchGetItem()
+        return this.dynamoDbAsyncClient.batchGetItemPaginator(batchGetItemRequest);
     }
 
     @Override

--- a/src/test/java/it/pagopa/pn/commons/utils/DynamoDbAsyncClientDecoratorTest.java
+++ b/src/test/java/it/pagopa/pn/commons/utils/DynamoDbAsyncClientDecoratorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.awssdk.services.dynamodb.paginators.BatchGetItemPublisher;
 import software.amazon.awssdk.services.dynamodb.paginators.QueryPublisher;
 import software.amazon.awssdk.utils.builder.SdkBuilder;
 
@@ -155,6 +156,14 @@ class DynamoDbAsyncClientDecoratorTest {
         UpdateItemResponse expectedValue = UpdateItemResponse.builder().consumedCapacity(ConsumedCapacity.builder().tableName("TABLE").build()).build();
         Mockito.when(delegate.updateItem(consumer)).thenReturn(CompletableFuture.completedFuture(expectedValue));
         assertThat(dynamoDbAsyncClientDecorator.updateItem(consumer).get()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void batchGetItemPaginator() {
+        BatchGetItemRequest request = BatchGetItemRequest.builder().build();
+        BatchGetItemPublisher publisher = new BatchGetItemPublisher(null, null);
+        Mockito.when(delegate.batchGetItemPaginator(request)).thenReturn(publisher);
+        assertThat(dynamoDbAsyncClientDecorator.batchGetItemPaginator(request)).isEqualTo(publisher);
     }
 
 }

--- a/src/test/java/it/pagopa/pn/commons/utils/DynamoDbEnhancedAsyncClientDecoratorTest.java
+++ b/src/test/java/it/pagopa/pn/commons/utils/DynamoDbEnhancedAsyncClientDecoratorTest.java
@@ -7,6 +7,8 @@ import org.mockito.Mockito;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPagePublisher;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 
 import java.util.concurrent.CompletableFuture;
@@ -46,5 +48,14 @@ class DynamoDbEnhancedAsyncClientDecoratorTest {
         Consumer<TransactWriteItemsEnhancedRequest.Builder> consumer = TransactWriteItemsEnhancedRequest.Builder::build;
         Mockito.when(delegate.transactWriteItems(consumer)).thenReturn(CompletableFuture.completedFuture(null));
         Assertions.assertDoesNotThrow(() -> dynamoDbEnhancedAsyncClientDecorator.transactWriteItems(consumer));
+    }
+
+    @Test
+    void batchGetItemTest() {
+        BatchGetItemEnhancedRequest request = BatchGetItemEnhancedRequest.builder().build();
+        Mockito.when(delegate.batchGetItem(request)).thenReturn(BatchGetResultPagePublisher.create(subscriber -> {
+
+        }));
+        Assertions.assertDoesNotThrow(() -> dynamoDbEnhancedAsyncClientDecorator.batchGetItem(request));
     }
 }


### PR DESCRIPTION
I metodi batchGetItem sono necessari per accedere in modalità batch a DynamoDB; questo consente di evitare accessi multipli alle tabelle quando occorrono più elementi date le partition keys ed eventuali sort keys.