### PR TITLE
Add type object to schemas

### DIFF
--- a/docs/openapi/pn-errors.yaml
+++ b/docs/openapi/pn-errors.yaml
@@ -23,6 +23,7 @@ paths:
 components:
   schemas:
     Problem:
+      type: object
       properties:
         type:
           description: URI reference of type definition
@@ -65,6 +66,7 @@ components:
         - status
         - errors
     ProblemError:
+      type: object
       properties:
         code:
           description: Internal code of the error, in human-readable format


### PR DESCRIPTION
Some of PagoPA's projects use the [openapi-codegen-ts](https://github.com/pagopa/openapi-codegen-ts) library to generate code from the OpenAPI.
It has some troubles when the type of a schema is not specified.

This PR should allow the generator to properly generate those types without manually change the OpenAPI file.